### PR TITLE
 feat(install.py): enhance installation script with argument parsing, Added fPIC compiler flags and integrate ccache 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,26 @@ set(CMAKE_CXX_STANDARD 14)
 set(TARGET_NAME ${PROJECT_NAME})
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug) # Debug/Release
+  set(CMAKE_BUILD_TYPE Release) # Debug/Release
 endif()
 
 enable_language(ASM)
 
 include(CMakePackageConfigHelpers)
 include(GNUInstallDirs)
+# ccache
+find_program(CCACHE_FOUND ccache)
+if (CCACHE_FOUND)
+  message(STATUS "### use ccache")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
+endif (CCACHE_FOUND)
+
+# fix for gcc 9
+#set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+#set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
 
 set(CROUTINE_FILE "cyber/croutine/detail/swap_x86_64.S")
 if(${CMAKE_SYSTEM_PROCESSOR} STREQUAL "x86_64")


### PR DESCRIPTION
 - The installation script now supports command-line argument parsing, allowing the specification
 the target platform and installation prefix.
 - Added a function to load the environment for potential cross-compilation scenarios.
 - Improved the download logic for the DDS package to only attempt download if the package is not
 already present.
 - Added a sleep delay for demonstration purposes


 - Changed the default build type from Debug to Release to optimize the build process.
 - Integrated ccache to speed up recompilation by caching previous compilations and detecting when
 the same compilation is being done again.
 - Added compiler flags to enable Position Independent Code (PIC), which is a requirement for shar
 libraries.
