### PR TITLE
Remove deprecated std::iterator

### DIFF
--- a/cyber/record/record_viewer.h
+++ b/cyber/record/record_viewer.h
@@ -95,8 +95,14 @@ class RecordViewer {
   /**
    * @brief The iterator.
    */
-  class Iterator : public std::iterator<std::input_iterator_tag, RecordMessage,
-                                        int, RecordMessage*, RecordMessage&> {
+  class Iterator {
+   public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = RecordMessage;
+    using difference_type = std::ptrdiff_t;
+    using pointer = RecordMessage*;
+    using reference = RecordMessage&;
+
    public:
     /**
      * @brief The constructor of iterator with viewer.


### PR DESCRIPTION
```cpp
In file included from /home/kino/cyberRT/cyber/record/record_viewer.cc:17:
/home/kino/cyberRT/cyber/record/record_viewer.h:98:32: warning: ‘template<class _Category, class _Tp, class _Distance, class _Pointer, class _Reference> struct std::iterator’ is deprecated [-Wdeprecated-declarations]
   98 |   class Iterator : public std::iterator<std::input_iterator_tag, RecordMessage,
      |                                ^~~~~~~~
In file included from /usr/include/c++/15.1.1/bits/stl_algobase.h:65,
                 from /usr/include/c++/15.1.1/bits/stl_tree.h:65,
                 from /usr/include/c++/15.1.1/map:64,
                 from /home/kino/cyberRT/cyber/record/record_viewer.h:22:
/usr/include/c++/15.1.1/bits/stl_iterator_base_types.h:129:34: note: declared here
  129 |     struct _GLIBCXX17_DEPRECATED iterator
      |                                  ^~~~~~~~

```