### PR TITLE
Fix posix shm loop

### DIFF
--- a/cyber/transport/shm/posix_segment.cc
+++ b/cyber/transport/shm/posix_segment.cc
@@ -251,7 +251,7 @@ bool PosixSegment::OpenOnly() {
 
   // get arena block buf
   uint32_t ai = 0;
-  for (; i < ShmConf::ARENA_BLOCK_NUM; ++ai) {
+  for (; ai < ShmConf::ARENA_BLOCK_NUM; ++ai) {
     uint8_t* addr = reinterpret_cast<uint8_t*>(
         static_cast<char*>(managed_shm_) + sizeof(State) + \
         conf_.block_num() * sizeof(Block) + ShmConf::ARENA_BLOCK_NUM * \


### PR DESCRIPTION
To fix this:
```E20251122 13:36:22.462062 429071 posix_segment.cc:269] [cyber_py]open only failed. [1] 429049 segmentation fault (core dumped) cyber_channel echo /tf_static```

Enabling POSIX shared memory causes core dumps when subscribing to channels such as `/tf_static`.